### PR TITLE
fix: Prevent sending empty administrators/drivers list in DriverGroupSetting

### DIFF
--- a/src/components/DriverGroupSetting/index.js
+++ b/src/components/DriverGroupSetting/index.js
@@ -114,8 +114,8 @@ export const DriverGroupSetting = (props) => {
     }
 
     const changes = isDriverManager
-      ? { administrators: JSON.stringify(changedUserIds) }
-      : { drivers: JSON.stringify(changedUserIds) }
+      ? { administrators: changedUserIds.length > 0 ? JSON.stringify(changedUserIds) : null }
+      : { drivers: changedUserIds.length > 0 ? JSON.stringify(changedUserIds) : null }
 
     handleUpdateDriversGroup(groupId, changes)
   }


### PR DESCRIPTION
Story: https://app.asana.com/0/0/1209411523387686